### PR TITLE
Ensure app is fully rendered

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,8 +47,10 @@ module.exports = {
             return chrome.kill();
           }
 
+          const url = path.join('http://localhost:4321', visitPath);
+
           const navigate = Page.enable()
-            .then(() => Page.navigate({ url: 'http://localhost:4321' }))
+            .then(() => Page.navigate({ url }))
             .then(() => Page.loadEventFired());
 
           return navigate


### PR DESCRIPTION
Closes #7
Closes #6

This change will wait for the Page.loadEventFired event, then will use
the Ember visit API to force an app boot, and will get the resulting
HTML only after the app's `afterRender` cycle is complete (the resolved
promise from the visit API)

The requirement for this is production is to export the app's global: https://github.com/ember-cli/ember-export-application-global#ember-export-application-global for all environments